### PR TITLE
Add async events queue so we can safely ignore event spitter

### DIFF
--- a/lib/firmata.rb
+++ b/lib/firmata.rb
@@ -1,2 +1,3 @@
 require 'firmata/version'
 require 'firmata/board'
+require 'firmata/event'

--- a/lib/firmata/event.rb
+++ b/lib/firmata/event.rb
@@ -1,0 +1,10 @@
+module Firmata
+  class Event
+    attr_reader :data, :name
+
+    def initialize(name, *data)
+      @name = name
+      @data = *data
+    end
+  end
+end


### PR DESCRIPTION
Needed to avoid callbacks outside of the Celluloid based message handling.
