### PR TITLE
Remove Invalid Signal Handler

### DIFF
--- a/lib/firmata/board.rb
+++ b/lib/firmata/board.rb
@@ -39,7 +39,7 @@ module Firmata
       @connected = false
       @async_events = []
 
-      trap_signals 'INT', 'KILL', 'TERM'
+      trap_signals 'INT', 'TERM'
     end
 
     # Public: Check if a connection to Arduino has been made.


### PR DESCRIPTION
Fixes #9

Quoting from [the man page](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/kill.1.html):

> KILL (non-catchable, non-ignorable kill)

Ruby 2.2 knows this.  Ruby is good.  Ruby is wise.